### PR TITLE
fix: correct server startup message

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ app.use('/api/users', userRoutes);
 
 // Bug: Missing error handling middleware
 app.listen(PORT, () => {
-  console.log(`Server is runing on port ${PORT}`);
+  console.log(`Server is running on port ${PORT}`);
 });
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- Fix the server startup log typo from `runing` to `running`.

## Verification
- `rg -n 'runing|Server is running' server.js` confirms the corrected message and no remaining misspelling.
- `node --check server.js` passed.
- `git diff --check` passed.

## Issue reference
Closes #1